### PR TITLE
improving logging

### DIFF
--- a/plugin/parse.go
+++ b/plugin/parse.go
@@ -72,11 +72,9 @@ func parsePipelines(data string, build drone.Build, repo drone.Repo, token strin
 					got, want := resource.Trigger.Paths.match(p), true
 					if got == want {
 						logrus.WithFields(logrus.Fields{
-							"action":    build.Action,
-							"after":     build.After,
-							"before":    build.Before,
-							"namespace": repo.Namespace,
-							"name":      repo.Name,
+							"build_id":       build.ID,
+							"repo_namespace": repo.Namespace,
+							"repo_name":      repo.Name,
 						}).Infoln("including pipeline", resource.Attrs["name"])
 
 						skipPipeline = false
@@ -85,11 +83,9 @@ func parsePipelines(data string, build drone.Build, repo drone.Repo, token strin
 				}
 				if skipPipeline {
 					logrus.WithFields(logrus.Fields{
-						"action":    build.Action,
-						"after":     build.After,
-						"before":    build.Before,
-						"namespace": repo.Namespace,
-						"name":      repo.Name,
+						"build_id":       build.ID,
+						"repo_namespace": repo.Namespace,
+						"repo_name":      repo.Name,
 					}).Infoln("excluding pipeline", resource.Attrs["name"])
 
 					// if only Trigger.Paths is set, Trigger.Attrs will be unset, so it must be initialized
@@ -119,11 +115,9 @@ func parsePipelines(data string, build drone.Build, repo drone.Repo, token strin
 						got, want := step.When.Paths.match(i), true
 						if got == want {
 							logrus.WithFields(logrus.Fields{
-								"action":    build.Action,
-								"after":     build.After,
-								"before":    build.Before,
-								"namespace": repo.Namespace,
-								"name":      repo.Name,
+								"build_id":       build.ID,
+								"repo_namespace": repo.Namespace,
+								"repo_name":      repo.Name,
 							}).Infoln("including step", step.Attrs["name"])
 
 							skipStep = false
@@ -132,11 +126,9 @@ func parsePipelines(data string, build drone.Build, repo drone.Repo, token strin
 					}
 					if skipStep {
 						logrus.WithFields(logrus.Fields{
-							"action":    build.Action,
-							"after":     build.After,
-							"before":    build.Before,
-							"namespace": repo.Namespace,
-							"name":      repo.Name,
+							"build_id":       build.ID,
+							"repo_namespace": repo.Namespace,
+							"repo_name":      repo.Name,
 						}).Infoln("excluding step", step.Attrs["name"])
 
 						// if only When.Paths is set, When.Attrs will be unset, so it must be initialized

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -85,22 +85,27 @@ func New(token string) converter.Plugin {
 func (p *plugin) Convert(ctx context.Context, req *converter.Request) (*drone.Config, error) {
 
 	logrus.WithFields(logrus.Fields{
-		"action":    req.Build.Action,
-		"after":     req.Build.After,
-		"before":    req.Build.Before,
-		"namespace": req.Repo.Namespace,
-		"name":      req.Repo.Name,
+		"build_action":   req.Build.Action,
+		"build_after":    req.Build.After,
+		"build_before":   req.Build.Before,
+		"build_id":       req.Build.ID,
+		"build_number":   req.Build.Number,
+		"build_parent":   req.Build.Parent,
+		"build_source":   req.Build.Source,
+		"build_ref":      req.Build.Ref,
+		"build_target":   req.Build.Target,
+		"build_trigger":  req.Build.Trigger,
+		"repo_namespace": req.Repo.Namespace,
+		"repo_name":      req.Repo.Name,
 	}).Infoln("initiated")
 
 	data := req.Config.Data
 	resources, pathsSeen, err := parsePipelines(data, req.Build, req.Repo, p.token)
 	if err != nil {
 		logrus.WithFields(logrus.Fields{
-			"action":    req.Build.Action,
-			"after":     req.Build.After,
-			"before":    req.Build.Before,
-			"namespace": req.Repo.Namespace,
-			"name":      req.Repo.Name,
+			"build_id":       req.Build.ID,
+			"repo_namespace": req.Repo.Namespace,
+			"repo_name":      req.Repo.Name,
 		}).Errorln(err)
 		return nil, nil
 	}
@@ -108,11 +113,9 @@ func (p *plugin) Convert(ctx context.Context, req *converter.Request) (*drone.Co
 	var config string
 	if pathsSeen {
 		logrus.WithFields(logrus.Fields{
-			"action":    req.Build.Action,
-			"after":     req.Build.After,
-			"before":    req.Build.Before,
-			"namespace": req.Repo.Namespace,
-			"name":      req.Repo.Name,
+			"build_id":       req.Build.ID,
+			"repo_namespace": req.Repo.Namespace,
+			"repo_name":      req.Repo.Name,
 		}).Infoln("paths fields were seen, marshaling config")
 
 		c, err := marshal(resources)
@@ -122,11 +125,9 @@ func (p *plugin) Convert(ctx context.Context, req *converter.Request) (*drone.Co
 		config = string(c)
 	} else {
 		logrus.WithFields(logrus.Fields{
-			"action":    req.Build.Action,
-			"after":     req.Build.After,
-			"before":    req.Build.Before,
-			"namespace": req.Repo.Namespace,
-			"name":      req.Repo.Name,
+			"build_id":       req.Build.ID,
+			"repo_namespace": req.Repo.Namespace,
+			"repo_name":      req.Repo.Name,
 		}).Infoln("no paths fields seen, no marshaling necessary")
 
 		config = data


### PR DESCRIPTION
"initiated" message provides more potentially helpful parameters for
troubleshooting

clean up other log messages and add req.Build.ID which should be unique and
useful for connecting all messages from a single build