### PR TITLE
handle commits with '--allow-empty'

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,7 @@ github.com/drone/drone-go v1.1.0 h1:2mritc5b7PhQWvILNyzaImZMRWVbMmmZ5Q0UDwwO7SI=
 github.com/drone/drone-go v1.1.0/go.mod h1:GxyeGClYohaKNYJv/ZpsmVHtMJ7WhoT+uDaJNcDIrk4=
 github.com/drone/go-scm v1.7.1 h1:wME/n7Qdo70VJ+WXZanJHjLtNWONEfjNsO2iwHDdlkE=
 github.com/drone/go-scm v1.7.1/go.mod h1:lXwfbyrIJwFFME5TpzavkwO2T5X8yBK6t6cve7g91x0=
+github.com/drone/go-scm v1.8.0 h1:kDHu38a11loKf6uaBu75TmY1YPwsSaZdseET738Oy0o=
 github.com/gfleury/go-bitbucket-v1 v0.0.0-20200810125852-15f2a16ca820 h1:WZjcz0B/K3rhvsu2HAmFRpgChrGVIBfvrmhwK2AdYYQ=
 github.com/gfleury/go-bitbucket-v1 v0.0.0-20200810125852-15f2a16ca820/go.mod h1:LB3osS9X2JMYmTzcCArHHLrndBAfcVLQAvUddfs+ONs=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=

--- a/plugin/parse.go
+++ b/plugin/parse.go
@@ -93,14 +93,19 @@ func parsePipelines(data string, build drone.Build, repo drone.Repo, changedFile
 			// there must be a better way to check whether paths.include or paths.exclude is set
 			if len(append(resource.Trigger.Paths.Include, resource.Trigger.Paths.Exclude...)) > 0 {
 				skipPipeline := true
-				for _, p := range changedFiles {
-					got, want := resource.Trigger.Paths.match(p), true
-					if got == want {
-						requestLogger.Infoln("including pipeline", resource.Attrs["name"])
+				if len(changedFiles) > 0 {
+					for _, p := range changedFiles {
+						got, want := resource.Trigger.Paths.match(p), true
+						if got == want {
+							requestLogger.Infoln("including pipeline", resource.Attrs["name"])
 
-						skipPipeline = false
-						break
+							skipPipeline = false
+							break
+						}
 					}
+					// in case of a '--allow-empty' commit, don't skip the pipeline
+				} else {
+					skipPipeline = false
 				}
 				if skipPipeline {
 					requestLogger.Infoln("excluding pipeline", resource.Attrs["name"])
@@ -120,14 +125,19 @@ func parsePipelines(data string, build drone.Build, repo drone.Repo, changedFile
 				// there must be a better way to check whether paths.include or paths.exclude is set
 				if len(append(step.When.Paths.Include, step.When.Paths.Exclude...)) > 0 {
 					skipStep := true
-					for _, i := range changedFiles {
-						got, want := step.When.Paths.match(i), true
-						if got == want {
-							requestLogger.Infoln("including step", step.Attrs["name"])
+					if len(changedFiles) > 0 {
+						for _, i := range changedFiles {
+							got, want := step.When.Paths.match(i), true
+							if got == want {
+								requestLogger.Infoln("including step", step.Attrs["name"])
 
-							skipStep = false
-							break
+								skipStep = false
+								break
+							}
 						}
+						// in case of a '--allow-empty' commit, don't skip the step
+					} else {
+						skipStep = false
 					}
 					if skipStep {
 						requestLogger.Infoln("excluding step", step.Attrs["name"])

--- a/plugin/parse_test.go
+++ b/plugin/parse_test.go
@@ -412,6 +412,65 @@ name: default
 	}
 }
 
+func TestParsePipelinesStepPathExcludeEmptyCommit(t *testing.T) {
+	req := &converter.Request{
+		Build: drone.Build{},
+		Repo: drone.Repo{
+			Slug:   "somewhere/over-the-rainbow",
+			Config: ".drone.yml",
+		},
+	}
+
+	before := `
+kind: pipeline
+type: docker
+name: default
+
+steps:
+- name: message
+  image: busybox
+  commands:
+  - echo "This step will be excluded when README.md is changed"
+  when:
+    paths:
+      exclude:
+      - README.md
+`
+	// parsed pipelines don't have a leading newline...
+	after := `kind: pipeline
+type: docker
+steps:
+- when:
+    paths:
+      exclude:
+      - README.md
+  commands:
+  - echo "This step will be excluded when README.md is changed"
+  image: busybox
+  name: message
+name: default
+`
+
+	// changedFiles can be empty in '--alow-empty' commits
+	changedFiles := []string{}
+	resources, err := parsePipelines(before, req.Build, req.Repo, changedFiles)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	c, err := marshal(resources)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	config := string(c)
+
+	if want, got := after, config; want != got {
+		t.Errorf("Want %v got %v", want, got)
+	}
+}
+
 func TestParsePipelinesStepPathIncludePipeline(t *testing.T) {
 	req := &converter.Request{
 		Build: drone.Build{},
@@ -511,6 +570,67 @@ name: default
 `
 
 	changedFiles := []string{"README.md"}
+	resources, err := parsePipelines(before, req.Build, req.Repo, changedFiles)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	c, err := marshal(resources)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	config := string(c)
+
+	if want, got := after, config; want != got {
+		t.Errorf("Want %v got %v", want, got)
+	}
+}
+
+func TestParsePipelinesTriggerPathExcludeEmptyCommit(t *testing.T) {
+	req := &converter.Request{
+		Build: drone.Build{},
+		Repo: drone.Repo{
+			Slug:   "somewhere/over-the-rainbow",
+			Config: ".drone.yml",
+		},
+	}
+
+	before := `
+kind: pipeline
+type: docker
+name: default
+
+trigger:
+  paths:
+    exclude:
+    - README.md
+
+steps:
+- name: message
+  image: busybox
+  commands:
+  - echo "README.md was changed"
+`
+
+	// parsed pipelines don't have a leading newline...
+	after := `kind: pipeline
+type: docker
+steps:
+- commands:
+  - echo "README.md was changed"
+  image: busybox
+  name: message
+trigger:
+  paths:
+    exclude:
+    - README.md
+name: default
+`
+
+	// changedFiles can be empty in '--alow-empty' commits
+	changedFiles := []string{}
 	resources, err := parsePipelines(before, req.Build, req.Repo, changedFiles)
 	if err != nil {
 		t.Error(err)


### PR DESCRIPTION
empty commits should not cause pipelines or pipeline steps to be excluded
if a trigger or path exclude is set