### PR TITLE
build images from 'scratch'

### DIFF
--- a/docker/Dockerfile.linux.amd64
+++ b/docker/Dockerfile.linux.amd64
@@ -1,7 +1,7 @@
 FROM alpine:3.10 as alpine
 RUN apk add -U --no-cache ca-certificates
 
-FROM alpine:3.10
+FROM scratch
 EXPOSE 3000
 
 ENV GODEBUG netdns=go

--- a/docker/Dockerfile.linux.arm64
+++ b/docker/Dockerfile.linux.arm64
@@ -1,7 +1,7 @@
 FROM alpine:3.10 as alpine
 RUN apk add -U --no-cache ca-certificates
 
-FROM alpine:3.10
+FROM scratch
 EXPOSE 3000
 
 ENV GODEBUG netdns=go


### PR DESCRIPTION
build docker imaged from the 'scratch' base image

this is better security practice and follows the practice of other drone
images (like drone-runner-docker)