### PR TITLE
Add a note about clashes with protected mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,3 +214,12 @@ anchor: &anchor
     event: push
     branch: master
 ```
+
+#### Protected Repos
+
+When this plugin is used in conjunction with [protected repos](https://docs.drone.io/signature/),
+signature validation will frequently fail.
+
+This occurs due to Drone's order of operations, in that the Drone file's 
+signature is checked after the this plugin has rewritten sections based on 
+the paths-changed triggers, resulting in a different signature for the file.


### PR DESCRIPTION
We ran into an issue when using this plugin with `protected` mode enabled on a repository in Drone.

This appears to be by design, but figured I'd add a note for anyone else who runs into this issue.