### PR TITLE
add dockerhub_config_pr secret

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -31,8 +31,6 @@ steps:
     dry_run: true
     dockerfile: docker/Dockerfile.linux.amd64
     repo: meltwater/drone-convert-pathschanged
-    config:
-      from_secret: dockerhub_config_pr
   when:
     event:
     - pull_request
@@ -43,8 +41,6 @@ steps:
     dry_run: true
     dockerfile: docker/Dockerfile.linux.arm64
     repo: meltwater/drone-convert-pathschanged
-    config:
-      from_secret: dockerhub_config_pr
   when:
     event:
     - pull_request
@@ -99,6 +95,9 @@ steps:
 trigger:
   branch:
   - master
+
+image_pull_secrets:
+- dockerhub_config_pr
 ---
 kind: secret
 name: dockerhub_config_pr
@@ -106,6 +105,6 @@ data: Dig1rK959v5NbLeLPhBH773S/nL0l27xbxnnaV545n2ndE2E6k1vBeTwrnmH23ZvYsVXg0kcMc
 
 ---
 kind: signature
-hmac: ac868a942531c1111efc8fb0e899ca2758af3568ece2b9f7716d448e0ac5054c
+hmac: 618da88ac08a9f98be696c6f048c3db5765bd9a78986956b3af1824c84db82f5
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -26,7 +26,7 @@ steps:
     - tag
 
 - name: publish_amd64_dry_run
-  image: plugins/docker:18
+  image: plugins/docker
   settings:
     dry_run: true
     dockerfile: docker/Dockerfile.linux.amd64
@@ -38,7 +38,7 @@ steps:
     - pull_request
 
 - name: publish_arm64_dry_run
-  image: plugins/docker:18
+  image: plugins/docker
   settings:
     dry_run: true
     dockerfile: docker/Dockerfile.linux.arm64
@@ -50,7 +50,7 @@ steps:
     - pull_request
 
 - name: publish_amd64
-  image: plugins/docker:18
+  image: plugins/docker
   settings:
     auto_tag: true
     auto_tag_suffix: linux-amd64
@@ -66,7 +66,7 @@ steps:
     - tag
 
 - name: publish_arm64
-  image: plugins/docker:18
+  image: plugins/docker
   settings:
     auto_tag: true
     auto_tag_suffix: linux-arm64

--- a/.drone.yml
+++ b/.drone.yml
@@ -31,6 +31,8 @@ steps:
     dry_run: true
     dockerfile: docker/Dockerfile.linux.amd64
     repo: meltwater/drone-convert-pathschanged
+    config:
+      from_secret: dockerhub_config_pr
   when:
     event:
     - pull_request
@@ -41,6 +43,8 @@ steps:
     dry_run: true
     dockerfile: docker/Dockerfile.linux.arm64
     repo: meltwater/drone-convert-pathschanged
+    config:
+      from_secret: dockerhub_config_pr
   when:
     event:
     - pull_request
@@ -96,7 +100,12 @@ trigger:
   branch:
   - master
 ---
+kind: secret
+name: dockerhub_config_pr
+data: Dig1rK959v5NbLeLPhBH773S/nL0l27xbxnnaV545n2ndE2E6k1vBeTwrnmH23ZvYsVXg0kcMcieCekASVj0MKL1ljVvcFXRWj+okY5eylPietQ5Kz6cnDVWkDyvppwR4JV6helOWqLXX7yFahJg+8r/fMtayOcmogWhrBEEqmU6VGK8EbsmPVgYdUBB7IR7Id0pEpTOyg==
+
+---
 kind: signature
-hmac: 352688b762156350d298d0493ba2da21138d343460dab70eb1b1a4465e940244
+hmac: ac868a942531c1111efc8fb0e899ca2758af3568ece2b9f7716d448e0ac5054c
 
 ...

--- a/.drone.yml
+++ b/.drone.yml
@@ -30,6 +30,10 @@ steps:
   settings:
     dry_run: true
     dockerfile: docker/Dockerfile.linux.amd64
+    username:
+      from_secret: dockerhub_username_pr
+    password:
+      from_secret: dockerhub_password_pr
     repo: meltwater/drone-convert-pathschanged
   when:
     event:
@@ -40,6 +44,10 @@ steps:
   settings:
     dry_run: true
     dockerfile: docker/Dockerfile.linux.arm64
+    username:
+      from_secret: dockerhub_username_pr
+    password:
+      from_secret: dockerhub_password_pr
     repo: meltwater/drone-convert-pathschanged
   when:
     event:
@@ -96,15 +104,8 @@ trigger:
   branch:
   - master
 
-image_pull_secrets:
-- dockerhub_config_pr
----
-kind: secret
-name: dockerhub_config_pr
-data: Dig1rK959v5NbLeLPhBH773S/nL0l27xbxnnaV545n2ndE2E6k1vBeTwrnmH23ZvYsVXg0kcMcieCekASVj0MKL1ljVvcFXRWj+okY5eylPietQ5Kz6cnDVWkDyvppwR4JV6helOWqLXX7yFahJg+8r/fMtayOcmogWhrBEEqmU6VGK8EbsmPVgYdUBB7IR7Id0pEpTOyg==
-
 ---
 kind: signature
-hmac: 618da88ac08a9f98be696c6f048c3db5765bd9a78986956b3af1824c84db82f5
+hmac: 74eb4f8adef025306784a612ad66ef6173879c3af59e3859782a0e0911975a92
 
 ...


### PR DESCRIPTION
a docker config file with authentication for hub.docker.com

this is for an account that does not have access to push images under
/meltwater, making it safer to expose in a pull request