### PR TITLE
[resolves #89] Add a configuration to set stash page size when comparing changes for change set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Unreleased
+
+### Added
+- [#89](https://github.com/meltwater/drone-convert-pathschanged/issues/89) add environment variable to allow stash users to specify page size of git compare changes
+
 ## 1.0.0
 
 ### Breaking changes

--- a/README.md
+++ b/README.md
@@ -125,6 +125,10 @@ $ docker run -d \
   --restart=always \
   --name=converter meltwater/drone-convert-pathschanged
 ```
+Stash APIs are paginated and by default will only return 25 changes when computing the changeset. Set environment variable STASH_PAGE_SIZE to a higher number on the plugin to avoid partial change set detection.
+```console
+--env=STASH_PAGE_SIZE=1000
+```
 
 4. Update your Drone server configuration to include the plugin address and the shared secret.
 

--- a/main.go
+++ b/main.go
@@ -34,6 +34,7 @@ type (
 		BitBucketPassword string `envconfig:"BITBUCKET_PASSWORD"`
 		GithubServer      string `envconfig:"GITHUB_SERVER"`
 		StashServer       string `envconfig:"STASH_SERVER"`
+		StashPageSize     int    `envconfig:"STASH_PAGE_SIZE"` //bumps the rest api page size for changeset detection. Picks only 25 changes if unspecified
 	}
 )
 
@@ -120,6 +121,7 @@ func main() {
 		GithubServer:      spec.GithubServer,
 		Token:             spec.Token,
 		StashServer:       spec.StashServer,
+		StashPageSize:     spec.StashPageSize,
 	}
 
 	handler := converter.Handler(

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -27,6 +27,7 @@ type (
 		GithubServer      string
 		StashServer       string
 		Token             string
+		StashPageSize     int
 	}
 
 	plugin struct {
@@ -166,7 +167,11 @@ func (p *plugin) Convert(ctx context.Context, req *converter.Request) (*drone.Co
 				return nil, err
 			}
 		case "stash":
-			changedFiles, err = providers.GetStashFilesChanged(req.Repo, req.Build, p.params.StashServer, p.params.Token, scm.ListOptions{})
+			listOptions := scm.ListOptions{}
+			if p.params.StashPageSize > 0 {
+				listOptions.Size = p.params.StashPageSize
+			}
+			changedFiles, err = providers.GetStashFilesChanged(req.Repo, req.Build, p.params.StashServer, p.params.Token, listOptions)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Fixes #89 

## Proposed Changes
Stash compare changes rest api is paginated and only returns first 25 paths changed. In monorepos change set can be over 25 and the pipelines evaluated with partial change set can be inaccurate.

Provide a configuration to set higher page size limit.

### Description

Added an environment config to specify page size and pass it onto GetStashFilesChanged if configured

### Checklist

- [X] Read the [**CONTRIBUTING**](CONTRIBUTING.md) document.
- [X] Read the [**CODE OF CONDUCT**](CODE_OF_CONDUCT.md) document.
- [X] Add tests to cover changes.
- [X] Ensure your code follows the code style of this project.
- [X] Ensure CI and all other PR checks are green OR
    - [X] Code compiles correctly.
    - [X] Created tests which fail without the change (if possible).
    - [X] All new and existing tests passed.
- [X] Add your changes to `Unreleased` section of [CHANGELOG](CHANGELOG.md).
- [X] Improve and update the [README](README.md) (if necessary).

